### PR TITLE
Rprofile for renv setup

### DIFF
--- a/.Rprofile
+++ b/.Rprofile
@@ -1,0 +1,1 @@
+source("renv/activate.R")

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 .Rhistory
 .RData
 .Ruserdata
-.Rprofile
 *.Rproj
 rmd_files/README.html
 renv/*


### PR DESCRIPTION
@chloepugh This update will activate renv automatically when the repo is cloned. Currently users have to run `renv::activate()` and `renv::restore()` to get set up. After this pr they will just need to run `renv::restore()`. Will check everything is working after merge.